### PR TITLE
Move babel dependencies to devDependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ node_modules
 lib
 
 yarn.lock
+
+# Editor artifacts
+.idea

--- a/package.json
+++ b/package.json
@@ -29,15 +29,17 @@
   "devDependencies": {
     "assume": "^1.5.2",
     "babel-cli": "^6.26.0",
+    "babel-preset-es2015": "^6.24.0",
     "babel-register": "^6.26.0",
+    "babelify": "^7.3.0",
     "eslint": "^4.2.0",
     "eslint-config-godaddy": "^2.0.0",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-mocha": "^4.11.0",
     "mocha": "^4.0.0",
     "pre-commit": "^1.2.2",
-    "react": "^15.6.1",
-    "react-native": "^0.46.1",
+    "react": "^15.4.2",
+    "react-native": "^0.42.3",
     "react-native-mock": "^0.3.1"
   },
   "pre-commit": "lint, test",
@@ -47,8 +49,6 @@
     ]
   },
   "dependencies": {
-    "babel-preset-es2015": "^6.24.0",
-    "babelify": "^7.3.0",
     "propget": "^1.1.0"
   },
   "babel": {
@@ -57,6 +57,7 @@
     ]
   },
   "peerDependencies": {
-    "react": "^15.6.1"
+    "react": "~15.4.1",
+    "react-native": "^0.42.3"
   }
 }


### PR DESCRIPTION
Since babel is only used at dev/build-time, those dependencies should be devDependencies. Fixing this reduces install bloat.